### PR TITLE
Fix Modal.vue background

### DIFF
--- a/resources/js/Components/Modal.vue
+++ b/resources/js/Components/Modal.vue
@@ -89,7 +89,7 @@ const maxWidthClass = computed(() => {
                 leave-from-class="opacity-100 translate-y-0 sm:scale-100"
                 leave-to-class="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-                <div v-show="show" class="mb-6 overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:mx-auto sm:w-full dark:bg-gray-800" :class="maxWidthClass">
+                <div v-show="show" class="relative mb-6 overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:mx-auto sm:w-full dark:bg-gray-800" :class="maxWidthClass">
                     <slot v-if="showSlot" />
                 </div>
             </transition>


### PR DESCRIPTION
Currently, when you open a modal e.g. click on the "Delete Account" button from the "Profile" page, the dimmed background extends over the modal content due to a z-order issue.

This is because eslint removes the `transform` class which is no longer needed in Tailwind v3. However, as per the upgrade guide https://tailwindcss.com/docs/upgrade-guide#automatic-transforms-and-filters there is one exception.

This PR replaces `transform` with a `relative` class to fix the issue.